### PR TITLE
feat: Add Together AI API support and initial configuration

### DIFF
--- a/new_rag_system/app/api/query.py
+++ b/new_rag_system/app/api/query.py
@@ -64,6 +64,7 @@ def query_documents(
 
     # Prepare LLM config dictionary for RAGSystem
     llm_config_for_rag = {
+        "type": llm_config_db.name.lower().split(" ")[0],
         "name": llm_config_db.name,
         "model_name": llm_config_db.model_name,
         "api_endpoint": llm_config_db.api_endpoint,

--- a/new_rag_system/app/database.py
+++ b/new_rag_system/app/database.py
@@ -22,8 +22,43 @@ def create_db_and_tables():
     """
     Creates the database and all tables defined in the models.
     This should be called once on application startup.
+    It also seeds the database with initial LLM configurations if none exist.
     """
+    # Import models here to prevent circular dependencies, as models import Base from this file.
+    from .models.llm_config import LLMConfig
+
     Base.metadata.create_all(bind=engine)
+
+    db = SessionLocal()
+    try:
+        # Check if there are any LLM configs already
+        if db.query(LLMConfig).count() == 0:
+            # Seed the database with default configurations
+            default_configs = [
+                LLMConfig(
+                    name="OpenAI GPT-3.5",
+                    model_name="gpt-3.5-turbo",
+                    api_key_env="OPENAI_API_KEY",
+                    is_default=True,
+                    is_api=False
+                ),
+                LLMConfig(
+                    name="Anthropic Claude 2",
+                    model_name="claude-2",
+                    api_key_env="ANTHROPIC_API_KEY",
+                    is_api=False
+                ),
+                LLMConfig(
+                    name="Together AI (Mixtral)",
+                    model_name="mistralai/Mixtral-8x7B-Instruct-v0.1",
+                    api_key_env="TOGETHER_API_KEY",
+                    is_api=False
+                ),
+            ]
+            db.add_all(default_configs)
+            db.commit()
+    finally:
+        db.close()
 
 # Dependency to get a DB session
 def get_db():

--- a/new_rag_system/app/rag.py
+++ b/new_rag_system/app/rag.py
@@ -2,7 +2,7 @@ import os
 import chromadb
 from langchain.text_splitter import RecursiveCharacterTextSplitter
 from langchain.prompts import PromptTemplate
-from langchain_community.chat_models import ChatOpenAI, ChatAnthropic
+from langchain_community.chat_models import ChatOpenAI, ChatAnthropic, ChatTogether
 from langchain_community.llms import Ollama
 from langchain_core.runnables import Runnable
 from langchain_huggingface import HuggingFaceEmbeddings
@@ -50,6 +50,13 @@ class RAGSystem:
             if not model_name:
                 model_name = "llama2"
             llm = Ollama(model=model_name, base_url=llm_config.get("api_endpoint", "http://localhost:11434"))
+        elif llm_type == "together":
+            if not model_name:
+                model_name = "mistralai/Mixtral-8x7B-Instruct-v0.1"
+            llm = ChatTogether(
+                model_name=model_name,
+                together_api_key=os.getenv(api_key_env or "TOGETHER_API_KEY"),
+            )
         else:
             raise ValueError(f"Unsupported LLM type: {llm_type}")
 

--- a/new_rag_system/requirements.txt
+++ b/new_rag_system/requirements.txt
@@ -24,4 +24,3 @@ jose
 chromadb
 langchain_community
 langchain-huggingface
-"passlib[bcrypt]"


### PR DESCRIPTION
This change introduces support for the Together AI API as a new LLM provider within the RAG system.

Key changes include:
- Added `langchain_community.chat_models.ChatTogether` to `app/rag.py` to handle requests to the Together API.
- Modified `app/database.py` to seed the database with a default configuration for Together AI ("Together AI (Mixtral)") on initial application startup. This ensures the new provider is immediately available.
- Added default configurations for OpenAI and Anthropic to the database seeding process for a better out-of-the-box experience.
- Fixed a bug in `app/api/query.py` where the `type` of the LLM was not being passed to the RAG system.
- Cleaned up a duplicate entry in `requirements.txt`.